### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/mgray0515/d5221025-b066-41aa-b8cb-81a88f2047b2/16179faa-5961-4120-b900-cc09e1682db9/_apis/work/boardbadge/4ccd203b-729a-4898-b80a-dcbcb25f0ae4)](https://dev.azure.com/mgray0515/d5221025-b066-41aa-b8cb-81a88f2047b2/_boards/board/t/16179faa-5961-4120-b900-cc09e1682db9/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/mgray0515/d5221025-b066-41aa-b8cb-81a88f2047b2/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.